### PR TITLE
Ignore __ prefixed servcmds

### DIFF
--- a/fpsgame/server.cpp
+++ b/fpsgame/server.cpp
@@ -4002,6 +4002,7 @@ namespace server
 
             case N_SERVCMD:
                 getstring(text, p);
+                if(!strncmp(text, "__", 2)) break;
                 spaghetti::simpleevent(N_SERVCMD, sender, p, curmsg, ci, cq, cm, text);
                 break;
 


### PR DESCRIPTION
I'd like to use `N_SERVCMD` to signal supported features to the server. Since these aren't a command they should be ignored.